### PR TITLE
update: Implement Sloan's proposed rule change

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -363,14 +363,23 @@ with the game as if the robot had not been returned.
 Only the referee decides whether a robot is damaged. A robot can only be taken
 off or returned with the referee's permission.
 
+\replaced[id=TC]
+{
+If both robots from the same team are deemed damaged at kickoff,
+gameplay will be paused and the remaining team will be awarded 1 goal for
+every 30 seconds that their oppent's robots remain damaged.
+}
+{
 If both robots from the same team are deemed damaged during gameplay, the clock
 continues and the remaining team gets one initial goal and rests while waiting
 for the opponent's return to play. The remaining team will also get one
 additional goal for each elapsed 30 seconds the opponent's robots remain
 damaged. Once a 10 goal difference occurs or the remaining time finishes, the
-team with no functional robots forfeits the game. However, these rules only
-apply when none of the two robots from the same team were damaged as the result
-of the opponent team violating the rules.
+team with no functional robots forfeits the game.
+}
+
+However, these rules only apply when none of the two robots from the same team
+were damaged as the result of the opponent team violating the rules.
 
 \subsection{Multiple defense \label{ref-013}}
 


### PR DESCRIPTION
### Please describe your change in one or two sentences

changes rules so that gameplay continues when a robot is damaged. here, if two robots are damaged at kickoff, play is suspended. In effect, the team with robots must score an empty net goal

### Please explain why do you think this change should be in the rules

Changes what happens when two robots from the same team are broken - play resumes, so the other team must score a goal against an empty net. As before, if a team cannot field a team at kickoff, play is paused and one point is awarded every 30 seconds.

------

**Note**: The text is copy-pasted from #14 where this change was first introduced by @gngrbrdmn.