### PR TITLE
pre-match meeting: Referee can check the robots

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -192,6 +192,10 @@ toss will settle for the other option. After the first half, teams will switch
 sides. The team not kicking off in the first half of the game will kick off to
 begin the second half of the game.
 
+\added[id=TC]{During the pre-match meeting the referee or their assistant may
+check whether the robots are capable of playing (i.e., whether they are at
+least able to follow and react to the ball).}
+
 \subsection{Kick-off \label{ref-004}}
 
 Each half of the game begins with a kick-off. All robots must be located on

--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -194,7 +194,9 @@ begin the second half of the game.
 
 \added[id=TC]{During the pre-match meeting the referee or their assistant may
 check whether the robots are capable of playing (i.e., whether they are at
-least able to follow and react to the ball).}
+least able to follow and react to the ball). If none of the robots is capable
+of playing, the game will not be played and zero goals will be awarded to both
+teams.}
 
 \subsection{Kick-off \label{ref-004}}
 


### PR DESCRIPTION

Signed-off-by: mr.Shu <mr@shu.io>

### Please describe your change in one or two sentences

Add a note to the pre-match meeting section allowing the referee or their assistant to check whether  the robots are capable of playing.

### Please explain why do you think this change should be in the rules

In order to make sure damaged robots or robots that are not working are not allowed to enter the gameplay.