### PR TITLE
out-of-bounds: A few changes

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -301,11 +301,13 @@ so, as described in 1.11.
 
 After the penalty time has passed, robot will be placed on the unoccupied
 neutral spot nearest to where it has been taken off, and not directly aiming
-towards the ball.
+towards the ball. \added[id=TC]{Alternatively, the referee may instruct the
+team to place the robot on the neutral spot on the side of the field
+currently farthest from the ball, not directly aiming towards the ball. }
 
 A referee can waive the penalty if the robot was accidentally pushed out of
-bounds by any other robot. In such a case, the referee may have to slightly
-push the robot back onto the field.
+bounds by \replaced[id=TC]{an opposing}{any other} robot. In such a case, the
+referee may have to slightly push the robot back onto the field.
 
 The ball can leave and bounce back into the playing field. The referee calls
 ``out of reach'', and will move the ball to the nearest unoccupied neutral spot

--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -303,7 +303,7 @@ After the penalty time has passed, robot will be placed on the unoccupied
 neutral spot nearest to where it has been taken off, and not directly aiming
 towards the ball. \added[id=TC]{Alternatively, the referee may instruct the
 team to place the robot on the neutral spot on the side of the field
-currently farthest from the ball, not directly aiming towards the ball. }
+currently farthest from the ball, oriented towards the closest wall. }
 
 A referee can waive the penalty if the robot was accidentally pushed out of
 bounds by \replaced[id=TC]{an opposing}{any other} robot. In such a case, the


### PR DESCRIPTION
### Please describe your change in one or two sentences

* Put the robot on the other side of the field after out of bounds has passed.

* Only put robots back when they are pushed out by a robot from another team.

### Please explain why do you think this change should be in the rules

> * Put the robot on the other side of the field after out of bounds has  passed.

It is quite difficult for the referee to remember where was a robot taken from. This gives them ability to put the robot "out of game" without having to remember where it was taken from.

> * Only put robots back when they are pushed out by a robot from another team.

This seems to have been a loophole in the rules, as it means that one robot may push another robot from the same team out of bounds and not be punished for doing that.

Restricting this rule to the robots of the opposing team should both make the rules a bit more fair and and the same time force the competitors to invest time into making sure they won't push their own robots out of bounds.