### PR TITLE
damaged-robots: A few updates

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -348,20 +348,25 @@ A robot is damaged especially when:
 
 Computers and repair equipment are not permitted in the playing area during
 gameplay. Usually, a team member will need to take the damaged robot to an
-``approved repair table'' near the playing area, located inside the competitors
-working area. A referee may permit robot sensor calibration, computers and
-other tools in the playing area, only for the 5 minutes before the start of
-each half.
+``approved repair table'' near the playing area.\deleted[id=TC]{, located
+inside the competitors working area.} A referee may permit robot sensor
+calibration, computers and other tools in the playing area, only for the 5
+minutes before the start of each half. \added[id=TC]{Reprogramming of robots
+during the gameplay can only happen when they are out of game (i.e., damaged
+or out of bounds), or when explicitly allowed by the referee.}
 
 After a robot has been fixed, it will be placed on the unoccupied neutral spot
 nearest to where it has been taken off, and not directly aiming towards the
-ball. A robot can only be returned to the field if the damage has been
+ball. \added[id=TC]{Alternatively, the referee may instruct the team to place
+the robot on the neutral spot on the side of the field currently farthest from
+the ball, not directly aiming towards the ball.}
+A robot can only be returned to the field if the damage has been
 repaired. If the referee notices that the robot was returned to the field with
 the same original problem, s/he could ask the robot to be removed, and proceed
 with the game as if the robot had not been returned.
 
-Only the referee decides whether a robot is damaged. A robot can only be taken
-off or returned with the referee's permission.
+\textbf{Only the referee decides whether a robot is damaged.} A robot can only
+be taken off or returned with the referee's permission.
 
 If both robots from the same team are deemed damaged during gameplay, the clock
 continues and the remaining team gets one initial goal and rests while waiting


### PR DESCRIPTION
### Please describe your change in one or two sentences

* Remove unnecessary parts

* Put robot on the other side of the field after the damage time has
  passed.

* Add a note on reprogramming.

### Please explain why do you think this change should be in the rules

> * Remove unnecessary parts

This seems to be causing issues internationally (when the playing area is not inside the working area) and does not really seem to be necessary.

> * Put robot on the other side of the field after the damage time has
  passed.

It is quite difficult for the referee to remember where was a robot taken from. This gives them ability to put the robot "out of game" without having to remember where it was taken from.

> * Add a note on reprogramming.

This causes some trouble when the kickoff does not start right away because the teams want to reprogram their robots. They may still do that, but only with explicit approval of the referee.
