### PR TITLE
update: Add safety updates

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -874,10 +874,14 @@ Since a contact with an opponent robot and/or dribbler that might damage some
 parts of robots cannot be fully anticipated, robots must have all its active
 elements properly protected with resistant materials. For example, electrical
 circuits and pneumatic devices, such as pipelines and bottles, must be
-protected from all human contact and direct contact with other robots. When
-batteries are transported or moved, it is recommended that safety bags be used.
-Reasonable efforts should be made to make sure that in all circumstances robots
-avoid short-circuits and chemical or air leaks.
+protected from all human contact and direct contact with other robots. 
+\added[id=TC]{All driven dribbler gears must be covered with metal or hard plastic.}
+
+When batteries are transported or moved, it is recommended that safety bags be
+used. Reasonable efforts should be made to make sure that in all circumstances
+robots avoid short-circuits and chemical or air leaks. \added[id=TC]{The use of 
+swollen, tattered or otherwise dangerous battery is not allowed.}
+
 
 \subsubsection{Programming \label{ref-058}}
 


### PR DESCRIPTION

### Please describe your change in one or two sentences

* Add note on dribbler gears

* Add note on batteries


### Please explain why do you think this change should be in the rules

- Dribbler gears have a huge potential to harm both participants and also referees -- covering them is the least the participants can do to for everyone's safety.

- Swollen batteries are a disaster waiting to happen -- they should be banned, which is what this change does.