### PR TITLE
update: Set countdown to three

### DIFF
--- a/tex/rules.tex
+++ b/tex/rules.tex
@@ -284,12 +284,12 @@ lack of progress situations are when the ball is stuck between robots, when
 there is no change in ball and robot's positions, or when the ball is beyond
 detection or reach capability of all robots on the field.
 
-After a visible and loud count\footnote{usually a count of five, the length of
-the count could be decided by the OC before a competition as long as it's
-the same length within a sub-league}, a referee will call ``lack of
-progress'' and will move the ball to the nearest unoccupied neutral spot. If
-this does not solve the lack of progress, the referee can move the ball to a
-different neutral spot.
+After a visible and loud count\footnote{usually a count of 
+\replaced[id=TC]{three}{five}, the length of the count could be decided by 
+the OC before a competition as long as it's the same length within a 
+sub-league}, a referee will call ``lack of progress'' and will move the ball 
+to the nearest unoccupied neutral spot. If this does not solve the lack of 
+progress, the referee can move the ball to a different neutral spot.
 
 \subsection{Out of bounds \label{ref-011}}
 
@@ -320,7 +320,8 @@ when one of the following condition occurs:
 
 \begin{enumerate}
     \item the ball remains outside the playing field too long,
-        after a visible and loud count, (usually a count of five, the length of
+        after a visible and loud count, (usually a count of 
+        \replaced[id=TC]{three}{five}, the length of
         the count can be decided by the OC before a competition as long as it
         is the same length within a sub-league)
 


### PR DESCRIPTION

### Please describe your change in one or two sentences

* Set countdown to three

### Please explain why do you think this change should be in the rules

Countdown at five has produced a lot of unnecessary waiting (see for instance the [discussion here](https://junior.forum.robocup.org/t/inspection-and-handling-of-lack-of-process-rule/693/6)) -- setting it at three should help.