### PR TITLE
update: `goal` -> `penalty area` in damaged robots

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -285,7 +285,7 @@ Some examples of a damaged robot include:
 
 * it does not respond to the ball, or is unable to move (it lost pieces,
 power, etc.).
-* it continually moves into the goal or out of the playing field.
+* it continually moves into the {~~goal~>penalty area~} or out of the playing field.
 * it turns over on its own accord.
 
 Computers and repair equipment are not permitted in the playing area during


### PR DESCRIPTION
### Please describe your change in one or two sentences

* Ensure the damaged robots section refers to robots moving to the penalty area instead of the goal.

### Please explain why do you think this change should be in the rules

* To better clarify the situation around the penalty vs. goal with regards to the new rules.