### PR TITLE
Clarify robot size as needing to fit cylinder

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -746,7 +746,7 @@ robot’s dimensions must not exceed the following limits:
 
 |===
 |sub-league | *Soccer* *Open* | *Soccer Lightweight*
-|size / diameter | {~~22.0~>18.0~~} cm | 22.0 cm +
+|size {~~/ diameter~>(robot must fit cylinder of this diameter)~~} | {~~22.0~>18.0~~} cm | 22.0 cm +
 |height | {~~22.0~>18.0~~} cm ^[1]^ | 22.0 cm ^[1]^ +
 |weight | {~~2400~>2200~~} g ^[2]^ | 1100 g ^[2]^ +
 |ball-capturing zone | {~~2.5~>1.5~~} cm | 3.0 cm +

--- a/rules.adoc
+++ b/rules.adoc
@@ -742,6 +742,8 @@ Soccer Lightweight sub-league are played using the IR ball.
 Robots will be measured in an upright position with all parts extended. A
 robot’s dimensions must not exceed the following limits:
 
+|===
+|sub-league | *Soccer* *Open* | *Soccer Lightweight*
 |size / (robot must fit cylinder of this diameter) | 18.0 cm | 22.0 cm +
 |height | 18.0 cm ^[1]^ | 22.0 cm ^[1]^ +
 |weight | 2200 g ^[2]^ | 1100 g ^[2]^ +

--- a/rules.adoc
+++ b/rules.adoc
@@ -285,7 +285,7 @@ Some examples of a damaged robot include:
 
 * it does not respond to the ball, or is unable to move (it lost pieces,
 power, etc.).
-* it continually moves into the {~~goal~>penalty area~} or out of the playing field.
+* it continually moves into the {~~goal~>penalty area~~} or out of the playing field.
 * it turns over on its own accord.
 
 Computers and repair equipment are not permitted in the playing area during


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Clarified robot size requirement as being size of a cylinder the robot needs to fit

### Please explain why do you think this change should be in the rules

We had a team at RCJ European Championship show up with a 22cm square robot that they went through a newly established CJ tournament with. This indicates the previous formulation to be ambiguous as multiple teams and regional OC must have considered this a correct interpretation.
