### PR TITLE
"Smoothly" fit cylinder

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -740,7 +740,7 @@ robot’s dimensions must not exceed the following limits:
 
 |===
 |sub-league | *Soccer* *Open* | *Soccer Lightweight*
-|size / (robot must fit smoothly cylinder of this diameter) | 18.0 cm | 22.0 cm +
+|size / (robot must fit {++smoothly++} cylinder of this diameter) | 18.0 cm | 22.0 cm +
 |height | 18.0 cm ^[1]^ | 22.0 cm ^[1]^ +
 |weight | 2200 g ^[2]^ | 1100 g ^[2]^ +
 |ball-capturing zone | 1.5 cm | 3.0 cm +

--- a/rules.adoc
+++ b/rules.adoc
@@ -740,7 +740,7 @@ robot’s dimensions must not exceed the following limits:
 
 |===
 |sub-league | *Soccer* *Open* | *Soccer Lightweight*
-|size / (robot must fit cylinder of this diameter) | 18.0 cm | 22.0 cm +
+|size / (robot must fit smoothly cylinder of this diameter) | 18.0 cm | 22.0 cm +
 |height | 18.0 cm ^[1]^ | 22.0 cm ^[1]^ +
 |weight | 2200 g ^[2]^ | 1100 g ^[2]^ +
 |ball-capturing zone | 1.5 cm | 3.0 cm +


### PR DESCRIPTION
### Please describe your change in one or two sentences
Add "Smoothly" before "fit cylinder" in the dimension section. 

### Please explain why do you think this change should be in the rules
In past years, there're several interpretations for "fit" so sometimes even robot fits in the cylinder by force, it could be "fit". 
To avoid this difference in interpretations, this word should be in. 
