### PR TITLE
dbscoach/add line tolerance

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -520,7 +520,7 @@ enough from the black exterior.
 === Floor
 
 The floor consists of dark green carpet on top of a hard level surface.  All
-straight lines on the field should be painted{~~ and have a width of 20 mm.~>.
+straight lines on the field should be painted {~~and have a width of 20 mm.~>.
 Lines should have a width of 20mm (±10%).~~}
 
 It is impractical to set international constraints on carpet other than it

--- a/rules.adoc
+++ b/rules.adoc
@@ -520,7 +520,8 @@ enough from the black exterior.
 === Floor
 
 The floor consists of dark green carpet on top of a hard level surface.  All
-straight lines on the field should be painted and have a width of 20 mm.
+straight lines on the field should be painted{~~ and have a width of 20 mm.~>.
+Lines should have a width of 20mm (±10%).~~}
 
 It is impractical to set international constraints on carpet other than it
 being dark green. In the spirit of the competition, teams should design robots


### PR DESCRIPTION
### Please describe your change in one or two sentences

Add +-10% tolerance on field line width

### Please explain why do you think this change should be in the rules

Widely used white tape is 19mm wide and adding tolerance brings this it into spec. Doesn't hurt for painted or carpeted lines either.