### PR TITLE
Update committee members with current (2022-08-01) committee

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -5,6 +5,7 @@
 
 \documentclass{article}
 
+\usepackage[utf8]{inputenc}
 
 \usepackage{graphicx}
 \usepackage{multirow}
@@ -102,6 +103,17 @@
 \begin{tabular}{rl}
 \resizebox{0.50\textwidth}{!}{
 \begin{tabular}{lr}
+    \multicolumn{2}{l}{\textbf{Soccer Technical Committee 2022:}}\\
+    Michael Ambrose           & USA\\
+    Javier E. Delgado Moreno  & Mexico \\
+    Hikaru Sugiura            & Japan\\
+    Marco Dankel              & Germany (CHAIR)\\
+    James Riley               & Australia\\
+    Adrián Matejov            & Slovakia\\
+\end{tabular}}
+&
+\resizebox{0.50\textwidth}{!}{
+\begin{tabular}{lr}
     \multicolumn{2}{l}{\textbf{Soccer Technical Committee 2020 and 2021:}}\\
     Georgia Gallant           & USA\\
     Javier E. Delgado Moreno  & Mexico \\
@@ -110,17 +122,8 @@
     Felipe Nascimento Martins & Netherlands\\
     Marek \v{S}uppa           & Slovakia (CHAIR)\\
 \end{tabular}}
-&
-\resizebox{0.50\textwidth}{!}{
-\begin{tabular}{lr}
-    \multicolumn{2}{l}{\textbf{Soccer Technical Committee 2019:}}\\
-    Tairo Nomura              & Japan\\
-    James Riley               & Australia\\
-    Mikail S. Arani           & Canada\\
-    Javier E. Delgado Moreno  & Mexico \\
-    Felipe Nascimento Martins & Netherlands\\
-    Marek \v{S}uppa           & Slovakia (CHAIR)\\
-\end{tabular}}
+
+
 
 \end{tabular}
 

--- a/preamble.tex
+++ b/preamble.tex
@@ -103,7 +103,7 @@
 \begin{tabular}{rl}
 \resizebox{0.50\textwidth}{!}{
 \begin{tabular}{lr}
-    \multicolumn{2}{l}{\textbf{Soccer Technical Committee 2022:}}\\
+    \multicolumn{2}{l}{\textbf{Soccer League Committee 2022:}}\\
     Michael Ambrose           & USA\\
     Javier E. Delgado Moreno  & Mexico \\
     Hikaru Sugiura            & Japan\\


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Updated 2023 draft rules with committee members as of 2022-08-01. Also title the list "Soccer League Committee" to make the title fit the document easily.

### Please explain why do you think this change should be in the rules

To be up to date and in line with the apparent new name of the committee.
