### PR TITLE
Advise teams to be prepared for deviations in golf ball parameters

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -1205,7 +1205,7 @@ meters onto a hardwood table or floor.
 The ball shall be of orange color. Since the definition of the orange color in
 general is not easy, any color that a human would deem to be orange and is
 substantially different from the other colors used on the field is acceptable.
-{++ While tournament organizers may supply matte balls to improve camera vision,
+{++While tournament organizers may supply matte balls to improve camera vision,
 if they do not teams must still be prepared to play with balls as supplied by 
 tournament organizers.++}
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -1202,15 +1202,19 @@ meters onto a hardwood table or floor.
 [[passive-coloration]]
 ==== Coloration
 
-The ball shall be of {++matte++} orange color. Since the definition of the orange color in
+The ball shall be of orange color. Since the definition of the orange color in
 general is not easy, any color that a human would deem to be orange and is
 substantially different from the other colors used on the field is acceptable.
+{++ While tournament organizers may supply matte balls to improve camera vision,
+if they do not teams must still be prepared to play with balls as supplied by 
+tournament organizers.++}
 
 [[passive-surface]]
 ==== Surface
 
 Engravings on the ball’s surface are tolerated. The inside of the ball should
-be hollow {++and the ball should not have a soft-touch finish.++}
+be hollow {++and the ball should not have a soft-touch finish. Teams must be 
+prepared to play with balls as supplied by tournament organizers.++}
 
 [[passive-weight]]
 ==== Weight


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Added language explicitly telling teams to be prepared for the ball to be different from what they would expect.

### Please explain why do you think this change should be in the rules

Tournament organizers might not be able to supply identical balls in all regions, therefore making coping with what will be available mandatory teams are warned to take variations into consideration.
