### PR TITLE
Limit maxmimum voltage anywhere to 48V and require measurability and …

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -793,7 +793,7 @@ sourced in any way the team sees fit.~~}
 Voltage pump circuits are permitted only for a kicker drive. {++No voltage may
 exceed 48V at any time and maximum boost voltage must be available for 
 demonstration and measurement at inspections. When not in use measurement
-contacts must be protected from accidental touches or short circuits. ++} All 
+contacts must be protected from accidental touches or short circuits.++} All 
 other
 electrical circuits inside the robot cannot exceed 15.0 V for Soccer Open and
 12.0 V for Soccer Lightweight. Each robot must be designed to allow verifying

--- a/rules.adoc
+++ b/rules.adoc
@@ -790,7 +790,11 @@ robot may use any number of cameras without any restrictions on lenses,
 optical parts, optical systems, and total field of view. Components may be
 sourced in any way the team sees fit.~~}
 
-Voltage pump circuits are permitted only for a kicker drive. All other
+Voltage pump circuits are permitted only for a kicker drive. {++ No voltage may
+exceed 48V at any time and maximum boost voltage must be available for 
+demonstration and measurement at inspections. When not in use measurement
+contacts must be protected from accidental touches or short circuits. ++} All 
+other
 electrical circuits inside the robot cannot exceed 15.0 V for Soccer Open and
 12.0 V for Soccer Lightweight. Each robot must be designed to allow verifying
 the voltage of power packs and its circuits, unless the nominal voltage is

--- a/rules.adoc
+++ b/rules.adoc
@@ -790,7 +790,7 @@ robot may use any number of cameras without any restrictions on lenses,
 optical parts, optical systems, and total field of view. Components may be
 sourced in any way the team sees fit.~~}
 
-Voltage pump circuits are permitted only for a kicker drive. {++ No voltage may
+Voltage pump circuits are permitted only for a kicker drive. {++No voltage may
 exceed 48V at any time and maximum boost voltage must be available for 
 demonstration and measurement at inspections. When not in use measurement
 contacts must be protected from accidental touches or short circuits. ++} All 


### PR DESCRIPTION
…safety measures

Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Introduced limit for maximum voltage anywhere in robot at 48V and require measurability and contact protection for voltage boost circuits.

### Please explain why do you think this change should be in the rules

With increased kicker power being permitted voltage pumps become more attractive and 48V is the globally harmonized "not dangerous high voltage" limit commonly used in industry (particularly automotive). This should get us on the good side of most if not all HV safety regulation.
