### PR TITLE
Made language around discqualification consistent to always be 'can be'

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -91,7 +91,7 @@ introducing new challenges and standard situations.
 Robots must be constructed and programmed exclusively by student members of the
 team. Mentors, teachers, parents or companies should not be involved in the
 design, construction, assembly, programming or debugging of robots. To avoid
-embarrassment and possible bcation, it is extremely important that
+embarrassment and possible disqualification, it is extremely important that
 teams abide by <<league-regulations>>, especially <<regulations-construction>>
 and <<regulations-programming>>, and all other competitor’s rules.
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -91,7 +91,7 @@ introducing new challenges and standard situations.
 Robots must be constructed and programmed exclusively by student members of the
 team. Mentors, teachers, parents or companies should not be involved in the
 design, construction, assembly, programming or debugging of robots. To avoid
-embarrassment and possible disqualification, it is extremely important that
+embarrassment and possible bcation, it is extremely important that
 teams abide by <<league-regulations>>, especially <<regulations-construction>>
 and <<regulations-programming>>, and all other competitor’s rules.
 
@@ -478,7 +478,7 @@ in <<league-regulations>>.
 Robots that do not abide by the specifications/regulations (see
 <<regulations>>) are not allowed to play, unless these rules specify otherwise.
 
-If violations are detected during a running game the team is disqualified for
+If violations are detected during a running game the team can be disqualified for
 that game.
 
 If similar violations occur repeatedly, the team can be disqualified from the
@@ -627,7 +627,7 @@ robots during normal game play.
 Robots are not allowed to cause damage to the field or to the ball during
 normal game play.
 
-A robot that causes damage may be disqualified from a specific match at the
+A robot that causes damage can be disqualified from a specific match at the
 referee’s discretion. The OC will also be informed.
 
 Humans are not allowed to cause deliberate interference with robots or damage


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Changed language around potential disqualification to always be "can be disqualified".

### Please explain why do you think this change should be in the rules

For consistency both inside the rules and with established practice.
