### PR TITLE
Remove reference to golf ball as hollow

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -1242,9 +1242,10 @@ tournament organizers.++}
 [[passive-surface]]
 ==== Surface
 
-Engravings on the ball’s surface are tolerated. The inside of the ball should
-be hollow {++and the ball should not have a soft-touch finish. Teams must be
-prepared to play with balls as supplied by tournament organizers.++}
+Engravings {++and printed labels++} on the ball’s surface are tolerated. 
+{~~The inside of the ball should be hollow ~>The the ball should not have 
+a soft-touch finish. Teams must be prepared to play with balls as supplied 
+by tournament organizers.~~}
 
 [[passive-weight]]
 ==== Weight


### PR DESCRIPTION
### Please describe your change in one or two sentences

Changed ball description to not refer to golf ball as hollow.

### Please explain why do you think this change should be in the rules

Golf balls unlike the previous passive balls are not hollow.
