### PR TITLE
Clarify that robots are to be placed inside the goal for kicker test

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -1264,7 +1264,7 @@ and by means of the Kicker Power Measuring Device in Soccer Lightweight.++}
 {++Kicker power measurement will be performed on-field in Soccer Open. The test
 is performed as follows:++}
 
-1.  {++Place robot at the back wall on the left side of the a goal.++}
+1.  {++Place robot inside the left corner of a goal.++}
 2.  {++Perform a kick into the opposing goal++}
 3.  {++The kicker power test is passed if after bouncing off of the opposite goal
 the ball does not return further than the front line of to the penalty area

--- a/rules.adoc
+++ b/rules.adoc
@@ -1262,7 +1262,7 @@ and by means of the Kicker Power Measuring Device in Soccer Lightweight.++}
 
 ==== Soccer Open Kicker Power Measurement
 {++Kicker power measurement will be performed on-field in Soccer Open. The test
-is performed as follows:++}
+will use the tournament ball. It is performed as follows:++}
 
 1.  {++Place robot inside the left corner of a goal.++}
 2.  {++Perform a kick into the opposing goal++}


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Clarify that robots are to be placed inside the goal for kicker test

### Please explain why do you think this change should be in the rules

It could currently be confusing whether the corner of the goal or of the field are being referred to.
