### PR TITLE
Put specification of goals to be colored back in

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -528,8 +528,9 @@ shaped.
 The goal "posts" are positioned over the white line marking the limits of the
 field.
 
-It is recommended that the blue be of a brighter shade so that it is different
-enough from the black exterior.
+The interior walls and of each goal are colored matte, one goal yellow and the
+other goal blue. It is recommended that the blue be of a brighter shade so that
+it is different enough from the black exterior.
 
 [[floor]]
 === Floor


### PR DESCRIPTION
### Please describe your change in one or two sentences

specify inside of goals to be colored yellow and blue and matte

### Please explain why do you think this change should be in the rules

That didn't got lost in the edit from 2020 to 2022 apparently
