### PR TITLE
dbscoach/remove kinds of fields

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -496,11 +496,6 @@ tournament.
 [[field]]
 == FIELD
 
-[[kind-of-field]]
-=== Kind of field
-
-There is only one kind of field for all sub-leagues.
-
 [[dimensions-of-the-field]]
 === Dimensions of the field
 


### PR DESCRIPTION
### Please describe your change in one or two sentences

Removed paragraph specifying there is only one kind of field

### Please explain why do you think this change should be in the rules

This was for the transistion from Soccer A/B to just soccer and is now long enough ago that it doesn't need to be mentioned anymore.
