### PR TITLE
Cleanup of old transitional provisions

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -899,11 +899,6 @@ regulations, for example, by a detailed documentation or logbook. Teams may be
 interviewed about their robots and the development process at any time during a
 tournament.
 
-See an example of the inspection sheet that tournament organizers will use in
-<<inspections-sheet-example>>. Note that the sheet will be updated by tournament organizers
-members before the competition to match this year’s rules, but the important
-aspects which are checked will stay the same.
-
 [[international-competition]]
 == INTERNATIONAL COMPETITION
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -496,11 +496,6 @@ tournament.
 [[field]]
 == FIELD
 
-[[kind-of-field]]
-=== Kind of field
-
-There is only one kind of field for all sub-leagues.
-
 [[dimensions-of-the-field]]
 === Dimensions of the field
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -907,9 +907,9 @@ tournament.
 
 Maximum team size is 4 members for RoboCupJunior Soccer.
 
-Starting in 2017, Soccer Lightweight team members can participate in the World
+Soccer Lightweight team members can participate in the World
 Championship only twice. After their second participation, they need to move to
-Soccer Open. Note that counting starts with the 2017 World Championship.
+Soccer Open.
 
 [[interviews]]
 === Interviews


### PR DESCRIPTION
### Please describe your change in one or two sentences

removed reference to 2017 from only 2x in LWL rule

### Please explain why do you think this change should be in the rules

That the count starts at 2017 can no longer be relevant for any teams within the age limits.