### PR TITLE
Updated for 2023 committee members

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -103,6 +103,17 @@
 \begin{tabular}{rl}
 \resizebox{0.50\textwidth}{!}{
 \begin{tabular}{lr}
+    \multicolumn{2}{l}{\textbf{Soccer League Committee 2023:}}\\
+    Michael Ambrose           & USA (CO-CHAIR)\\
+    Javier E. Delgado Moreno  & Mexico \\
+    Hikaru Sugiura            & Japan\\
+    David Schwarz             & Germany (CHAIR)\\
+    William Plummer           & Australia\\
+    Adrián Matejov            & Slovakia\\
+\end{tabular}}
+&
+\resizebox{0.50\textwidth}{!}{
+\begin{tabular}{lr}
     \multicolumn{2}{l}{\textbf{Soccer League Committee 2022:}}\\
     Michael Ambrose           & USA\\
     Javier E. Delgado Moreno  & Mexico \\
@@ -110,17 +121,6 @@
     Marco Dankel              & Germany (CHAIR)\\
     James Riley               & Australia\\
     Adrián Matejov            & Slovakia\\
-\end{tabular}}
-&
-\resizebox{0.50\textwidth}{!}{
-\begin{tabular}{lr}
-    \multicolumn{2}{l}{\textbf{Soccer Technical Committee 2020 and 2021:}}\\
-    Georgia Gallant           & USA\\
-    Javier E. Delgado Moreno  & Mexico \\
-    Hikaru Sugiura            & Japan\\
-    Marco Dankel              & Germany\\
-    Felipe Nascimento Martins & Netherlands\\
-    Marek \v{S}uppa           & Slovakia (CHAIR)\\
 \end{tabular}}
 
 


### PR DESCRIPTION
Signed-off-by: David Schwarz <rcj-soccer-github@davidschwarz.info>

### Please describe your change in one or two sentences

Moved 2022 committee members to "last year" spot and entered new ones.

### Please explain why do you think this change should be in the rules

To be up to date. Ideally I'd like to merge this and the updated field construction drawing into master simultaneously so we get only one revision of the rules.
