### PR TITLE
Added cavated version and little explainer about 5-member-rule for soccer

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -99,6 +99,14 @@ Detailed changes are listed below and link to the corresponding place in the rul
 
 {+-~TOC-CHANGES~-+}
 
+* A notable change that cannot be highlighted the same way as others is the
+maximum team size: We're changing the default from 4 to 5 members maximum.
+Regions are free to remain at 4 (or any other number they may want to set) if
+that is what is best in their situation so please as always check with your
+tournaments' organizers what rules they will be running. If you haven't yet
+shared your thoughts on this change in the rules discussion phase we're still
+interested to hear them, come talk to us on the Forum or the Discord.
+
 [[gameplay]]
 == GAMEPLAY
 
@@ -574,11 +582,22 @@ Robots must be inspected and certified every day before the first game is
 played. The tournament organizers may request other inspections if necessary,
 including random inspections which may happen at any time.
 
-[[international-competition]]
-== INTERNATIONAL COMPETITION
-
 [[international-competition-specifics]]
-=== International Competition Specifics
+== International Competition Specifics
+
+[[team-size]]
+=== Team Size
+
+Because the international competition is in a different location every year it
+can not be guaranteed that there will be enough seats in the Junior Soccer area
+for every member of a 5-member-team to be able to sit. It may not be possible
+to register all 5 team members as regular team members. Certificates and awards
+will be issue to all 5 actual members but depending on fire safety an space
+limitations measures like limiting access to the team area to 4 team members
+at a time and/or other "creative solutions" may habe to be employed.
+
+[[communications-module]]
+=== Communications Module
 
 At the international competition (for others ask organizers) the Soccer League
 Committee will provide each team with a Communication Module. This allow for 

--- a/rules.adoc
+++ b/rules.adoc
@@ -594,7 +594,7 @@ for every member of a 5-member-team to be able to sit. It may not be possible
 to register all 5 team members as regular team members. Certificates and awards
 will be issue to all 5 actual members but depending on fire safety an space
 limitations measures like limiting access to the team area to 4 team members
-at a time and/or other "creative solutions" may habe to be employed.
+at a time and/or other "creative solutions" may have to be employed.
 
 [[communications-module]]
 === Communications Module


### PR DESCRIPTION
### Please describe your change in one or two sentences

It's mostly the addition of the explainer and the pointing to the draft commit in the general rules (with also added footnote) for the 5 member addition

### Please explain why do you think this change should be in the rules

I think it is important that the participant and mentor-facing part of the rules (for most of whom going to internationals is of no concern) has the 5 member maximum as the (opt-outable in the unlikely[1] case that regions have issues with it)default for the reasons outlined on the forum and the Discord. The draft phase of the rules now as the seasons starts up is the best shot we have at getting any possible negative feedback from regions rolling out new rules to their teams in modified or unmodified form as the season is now starting up.

PDF should be available at https://robocup-junior.github.io/soccer-rules/dschwarz/soccer-rules-5-members/rules.pdf as soon as CI finishes.