### PR TITLE
Fix: redirect root GitHub Pages URL to rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           mkdir -p dist/${GITHUB_REF#refs/heads/}/
           rm tmp_*
           cp -R ./media *.html *.pdf dist/${GITHUB_REF#refs/heads/}/
+          cp index.html dist/index.html
 
       - name: publish the rules
         uses: peaceiris/actions-gh-pages@v3

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=master/rules.html">
+  <link rel="canonical" href="master/rules.html">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>Redirecting to <a href="master/rules.html">master/rules.html</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Visiting https://robocup-junior.github.io/soccer-rules/ currently returns a 404
- This adds an `index.html` that redirects to `master/rules.html` via `<meta http-equiv="refresh">`
- The CI workflow copies it into `dist/` so it gets deployed to the root of `gh-pages`

## Test plan

- [ ] Verify the CI build passes
- [ ] After deploy, confirm https://robocup-junior.github.io/soccer-rules/ redirects to https://robocup-junior.github.io/soccer-rules/master/rules.html