### PR TITLE
Explicit advice about red lights

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -342,6 +342,13 @@ playing when placed on a flat surface. Any part of a robot that produces light
 that may interfere with the opposing robot’s vision system must be covered.
 For Infrared league specific regulations see <<regulations-inference-in-infrared>>
 
+IMPORTANT: {++These interference rules mean that often red lights (e.g. line
+sensors) are detected by other teams's camera system as th orange ball and
+therefore must be covered up for the robot to be allowed to play. This has been
+the case in Vision for may years but may be new to Infrared teams. Teams are
+advised to make sure their robots do not have these bright red lights/lights
+to avoid having to make surprise adjustments at the competition.++}
+
 Robots are expected to be capable of dealing with any visible colors above the
 walls (e.g. blue, yellow, green or orange shirts) either in hardware (e.g. 
 limiting the field of view from looking up) or in software (e.g. masking

--- a/rules.adoc
+++ b/rules.adoc
@@ -343,9 +343,9 @@ that may interfere with the opposing robot’s vision system must be covered.
 For Infrared league specific regulations see <<regulations-inference-in-infrared>>
 
 IMPORTANT: {++These interference rules mean that often red lights (e.g. line
-sensors) are detected by other teams's camera system as th orange ball and
+sensors) are detected by other teams's camera system as the orange ball and
 therefore must be covered up for the robot to be allowed to play. This has been
-the case in Vision for may years but may be new to Infrared teams. Teams are
+the case in Vision for many years but may be new to Infrared teams. Teams are
 advised to make sure their robots do not have these bright red lights/lights
 to avoid having to make surprise adjustments at the competition.++}
 


### PR DESCRIPTION
### Please describe your change in one or two sentences

Added as explicit as possible hint for teams to ensure they don't have bright red things/lights or that they can still operate if those need to be covered.

### Please explain why do you think this change should be in the rules

We've head Infrared teams be surprised by red lights being an issue as they haven't experienced playing against teams looking for the orange ball before. 
